### PR TITLE
Timed pings

### DIFF
--- a/app/UI/Component/Logging/Toast.purs
+++ b/app/UI/Component/Logging/Toast.purs
@@ -58,10 +58,7 @@ component =
   where
     initialState :: State
     initialState = 
-      { toastMsg: Just
-          { _type: Success
-          , message: "Woo!"
-          }
+      { toastMsg: Nothing
       }
 
     handleAction :: Action -> H.HalogenM State Action () Message m Unit

--- a/app/UI/Component/Root.purs
+++ b/app/UI/Component/Root.purs
@@ -86,7 +86,7 @@ component =
     handleAction = case _ of
       Initialize -> do
         AppEnv {web3Provider, contracts: {relayableNFT}} <- ask
-        void $ H.subscribe $ ES.effectEventSource (\emitter -> do
+        void $ H.subscribe $ ES.effectEventSource \emitter -> do
           let 
               filters = 
                 { mint: eventFilter (Proxy :: Proxy RNFT.MintedByRelay) relayableNFT
@@ -148,7 +148,12 @@ component =
                     Console.log $ "Polling RelayableNFT terminated by app at block " <> show receipt.blockNumber
                 liftEffect $ ES.emit emitter $ SendToastMsg {_type: Toast.Warn, message: "Event filter terminated!"}
           pure $ Finalizer $ launchAff_ $ killFiber (error "Component teardown") fibre
-          )
+        let successfulStartMsg = 
+                { _type: Toast.Info
+                , message: "Monitoring Ethereum for FOAM Lite transactions."
+                }
+        _ <- H.query Toast._toast unit $ H.tell (Toast.DisplayMsg successfulStartMsg)
+        pure unit
       SendToastMsg msg -> do
         _ <- H.query Toast._toast unit $ H.tell (Toast.DisplayMsg msg)
         pure unit


### PR DESCRIPTION
When transactions with location metadata come through, we want the point to ping for a certain amount of time (5s) then stop pinging.

also rather than have the app start up with state present, I am now waiting a few seconds before intiializing the state so you can get a feel for what it looks like when it's live.